### PR TITLE
hotfix: amend create_wallet.sh

### DIFF
--- a/utilities/create_wallet.sh
+++ b/utilities/create_wallet.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 
 # ------------------------------------------------------------------------------------- GLOBALS
 
-WALLET_LOC=${HOME}/tns
+WALLET_LOC=${1:-${HOME}/tns}
 
 # ------------------------------------------------------------------------------------- MAIN
 
@@ -57,9 +57,9 @@ read -p "Enter the user to connect to: " username
 read -sp "Enter the user's password: " user_pwd
 echo
 read -p "Enter the hostname/scan of your RAC/single instance database: " host_name
-read -p "Enter the (SCAN) listener port (defaults to 1521): " listner_port
+read -p "Enter the (SCAN) listener port (defaults to 1521): " listener_port
 
-/usr/bin/mkdir "${WALLET_LOC}" || {
+/usr/bin/mkdir -vp "${WALLET_LOC}" || {
 	echo "ERR: could not create ${WALLET_LOC} for some reason, weird. Exiting"
 	exit 1
 }


### PR DESCRIPTION
`create_wallet.sh` had a couple of issues:

1. typo referring to the listener_port preventing the correct creation of the `tnsnames.ora` file
1. it didn't allow a custom directory for the wallet creation to be specified

All issues are now addressed, and tested.